### PR TITLE
Add new card types and improve special effect handling

### DIFF
--- a/game.py
+++ b/game.py
@@ -57,7 +57,10 @@ class Game:
             ("Disrupt", CardType.TRICK, 5, 1, 1, "Foe Slow 2 this beat; deal 1", "", ""),
             ("Focus", CardType.PREP, 2, 0, 3, "Heal 2; next beat +1 Stability", "Effect: heal", ""),
             ("Ignite", CardType.SKILL, 3, 1, 2, "Deal 1; Bleed 1 (2 beats)", "Read: +Bleed 1", ""),
-            ("Feint", CardType.TRICK, 6, 1, 1, "After reveal, swap with unplayed; resolves S5", "Read: +1 dmg", "")
+            ("Feint", CardType.TRICK, 6, 1, 1, "After reveal, swap with unplayed; resolves S5", "Read: +1 dmg", ""),
+            ("Piercing Strike", CardType.ATTACK, 3, 3, 2, "Deal 3; Ignore guard", "", ""),
+            ("Deep Cut", CardType.ATTACK, 4, 1, 2, "Deal 1; Bleed 2 (3 beats)", "Read: +1 dmg", ""),
+            ("Reinforce", CardType.GUARD, 2, 0, 4, "Prevent 6", "", "")
         ]
         
         for name, card_type, speed, damage, stability, effect, read, clash in starter_cards:


### PR DESCRIPTION
## Summary
- introduce Piercing Strike, Deep Cut, and Reinforce to the starting deck
- support ignore-guard damage along with parsing for generic guard and bleed effects

## Testing
- `python -m py_compile combat.py game.py`


------
https://chatgpt.com/codex/tasks/task_e_68afc35094a0832da6859898fd798085